### PR TITLE
Add nodeinfo1 datatype schema to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ FROM alpine:3.7
 # Add all binaries that we may want to run that are not in alpine by default.
 RUN apk add --no-cache lshw
 COPY --from=build /go/bin/nodeinfo /
+COPY --from=build /go/src/github.com/m-lab/nodeinfo/api/nodeinfo1.json /var/spool/datatypes/nodeinfo1.json
 WORKDIR /
 # Make sure /nodeinfo can run (has no missing external dependencies).
 RUN /nodeinfo -h 2> /dev/null

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,12 @@ CONFIG=./testdata/config.json
 DATADIR=./testdata
 DATATYPE=nodeinfo1
 
+compose:
+	mkdir -p ./testdata/gcs/autoload/v1
+	mkdir -p ./testdata/var/spool/datatypes ./testdata/var/spool/experiment/nodeinfo1
+	cp ./api/nodeinfo1.json testdata/var/spool/datatypes/nodeinfo1.json
+	docker-compose up --abort-on-container-exit
+
 run: nodeinfo
 	rm -rf $(DATADIR)/$(DATATYPE)
 	./nodeinfo -config $(CONFIG) -datadir $(DATADIR) -once -smoketest -wait 1s; echo; tree $(DATADIR); echo

--- a/api/nodeinfo1.json
+++ b/api/nodeinfo1.json
@@ -1,0 +1,24 @@
+[
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "Output",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "CommandLine",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "Name",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "commands",
+    "type": "RECORD"
+  }
+]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,29 @@
+version: '3.7'
+services:
+  nodeinfo:
+    image: nodeinfo:latest
+    volumes:
+      - ./testdata:/testdata
+    command:
+      - -config=./testdata/config.json
+      - -datadir=/testdata/var/spool/experiment
+      - -wait=15s
+
+  jostler:
+    image: jostler:latest
+    volumes:
+      - ./testdata:/testdata
+    command:
+      - -gcs-local-disk
+      - -mlab-node-name=experiment-mlab1-lga01.mlab-sandbox.measurement-lab.org
+      - -gcs-bucket=newclient,download,upload
+      - -gcs-data-dir=/testdata/gcs/autoload/v1
+      - -local-data-dir=/testdata/var/spool
+      - -experiment=experiment
+      - -datatype=nodeinfo1
+      - -datatype-schema-file=nodeinfo1:/testdata/var/spool/datatypes/nodeinfo1.json
+      - -bundle-size-max=200000
+      - -bundle-age-max=60s
+      - -missed-age=60s
+      - -missed-interval=15s
+      - -verbose


### PR DESCRIPTION
This commit adds the datatype schema file api/nodeinfo1.json to nodeinfo container image at /var/spool/datatypes so jostler could verify there are no breaking changes in the table schema.

This commit also adds docker-compose.yaml for local testing of nodeinfo and jostler working together.

There are no changes in this commit to nodeinfo logic.

Changes were tested locally.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/nodeinfo/17)
<!-- Reviewable:end -->
